### PR TITLE
Fix notices on initial use of theme from strpos

### DIFF
--- a/view/common/block-layout/browse-preview.phtml
+++ b/view/common/block-layout/browse-preview.phtml
@@ -10,11 +10,11 @@ $filterLocale = (bool) $this->siteSetting('filter_locale_values');
 $lang = $this->lang();
 $valueLang = $filterLocale ? [$lang, ''] : null;
 
-$layoutSetting = $this->themeSetting('browse_layout');
+$layoutSetting = $this->themeSetting('browse_layout', 'grid');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 $gridState = ($layoutSetting == 'togglegrid') ? 'disabled' : '';
 $listState = ($layoutSetting == 'togglelist') ? 'disabled': '';
-$currentLayout = (!isset($layoutSetting) || strpos($layoutSetting, 'grid') !== false) ? 'grid' : 'list';
+$currentLayout = (strpos($layoutSetting, 'grid') !== false) ? 'grid' : 'list';
 $isGrid = ($currentLayout == 'grid') ? true : false;
 $queryUrl = $this->url(
     'site/resource', ['controller' => $this->resourceType, 'action' => 'browse'], ['query' => $this->query], true

--- a/view/omeka/site/item-set/browse.phtml
+++ b/view/omeka/site/item-set/browse.phtml
@@ -9,10 +9,10 @@ $filterLocale = (bool) $this->siteSetting('filter_locale_values');
 $lang = $this->lang();
 $valueLang = $filterLocale ? [$lang, ''] : null;
 
-$layoutSetting = $this->themeSetting('browse_layout');
+$layoutSetting = $this->themeSetting('browse_layout', 'grid');
 $gridState = ($layoutSetting == 'togglegrid') ? 'disabled' : '';
 $listState = ($layoutSetting == 'togglelist') ? 'disabled': '';
-$isGrid = (!isset($layoutSetting) || strpos($layoutSetting, 'grid') !== false) ? true : false;
+$isGrid = (strpos($layoutSetting, 'grid') !== false) ? true : false;
 $bodyTerm = $this->siteSetting('browse_body_property_term');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 $decoration = $this->themeSetting('image_decoration');

--- a/view/omeka/site/item/browse.phtml
+++ b/view/omeka/site/item/browse.phtml
@@ -26,10 +26,10 @@ if ($itemSetShow) {
     $query['item_set_id'] = $itemSet->id();
 }
 
-$layoutSetting = $this->themeSetting('browse_layout');
+$layoutSetting = $this->themeSetting('browse_layout', 'grid');
 $gridState = ($layoutSetting == 'togglegrid') ? 'disabled' : '';
 $listState = ($layoutSetting == 'togglelist') ? 'disabled': '';
-$isGrid = (!isset($layoutSetting) || strpos($layoutSetting, 'grid') !== false) ? true : false;
+$isGrid = (strpos($layoutSetting, 'grid') !== false) ? true : false;
 $bodyTerm = $this->siteSetting('browse_body_property_term');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 $decoration = $this->themeSetting('image_decoration');

--- a/view/omeka/site/media/browse.phtml
+++ b/view/omeka/site/media/browse.phtml
@@ -9,10 +9,10 @@ $filterLocale = (bool) $this->siteSetting('filter_locale_values');
 $lang = $this->lang();
 $valueLang = $filterLocale ? [$lang, ''] : null;
 
-$layoutSetting = $this->themeSetting('browse_layout');
+$layoutSetting = $this->themeSetting('browse_layout', 'grid');
 $gridState = ($layoutSetting == 'togglegrid') ? 'disabled' : '';
 $listState = ($layoutSetting == 'togglelist') ? 'disabled': '';
-$isGrid = (!isset($layoutSetting) || strpos($layoutSetting, 'grid') !== false) ? true : false;
+$isGrid = (strpos($layoutSetting, 'grid') !== false) ? true : false;
 $bodyTerm = $this->siteSetting('browse_body_property_term');
 $bodyTruncate = $this->themeSetting('truncate_body_property');
 $decoration = $this->themeSetting('image_decoration');


### PR DESCRIPTION
In PHP 8.1+, passing null to strpos generates a notice, and the theme uses it several times against the browse_layout setting. The settings are only null until the user goes and edits them.

This fixes the problem by setting a default value of "grid" to use for the setting instead of manually checking for null. This fix is more or less ported from Foundation which uses pretty much the same code and system.