### PR TITLE
Fix value options in linked resources

### DIFF
--- a/view/common/linked-resources.phtml
+++ b/view/common/linked-resources.phtml
@@ -39,11 +39,17 @@ foreach ($resourcePropertiesAll as $type => $resourceProperties) {
         'options' => [sprintf('%s:', $type) => sprintf('%s: All', $labelMap[$type])],
     ];
     foreach ($resourceProperties as $resourceProperty) {
-        $key = sprintf('%s:%s', $type, $resourceProperty['id_concat']);
-        $value = $resourceProperty['property_alternate_label']
-            ? $this->translate($resourceProperty['property_alternate_label'])
-            : $this->translate($resourceProperty['property_label']);
-        $valueOptions[$type]['options'][$key] = sprintf('%s: %s', $labelMap[$type], $value);
+        $label = $resourceProperty['label_is_translatable']
+            ? $this->translate($resourceProperty['label'])
+            : $resourceProperty['label'];
+
+        $valueOptions[$type]['options'][] = [
+            'value' => $resourceProperty['compound_id'],
+            'label' => sprintf('%s: %s', $labelMap[$type], $label),
+            'attributes' => [
+                'title' => $resourceProperty['term'],
+            ],
+        ];
     }
 }
 $resourcePropertiesSelect->setValueOptions($valueOptions);


### PR DESCRIPTION
See [this forum post](https://forum.omeka.org/t/freedom-theme-linked-resources-filter-by-resource-type-and-property-not-working/22394).

Omeka S 4.1 changed the structure of the value options for the linked resources select menu. This PR fixes it.